### PR TITLE
override rabbit config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apk update && \
 USER rabbitmq
 
 COPY docker-entrypoint.sh /
+COPY rabbitmq.config /usr/lib/rabbitmq/etc/rabbitmq/rabbitmq.config
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["/usr/lib/rabbitmq/sbin/rabbitmq-server"]

--- a/rabbitmq.config
+++ b/rabbitmq.config
@@ -1,0 +1,22 @@
+[
+  {
+    rabbit,
+    [
+      {loopback_users, []},
+      {cluster_partition_handling, autoheal},
+      {delegate_count, 64},
+      {fhc_read_buffering, false},
+      {fhc_write_buffering, false},
+      {heartbeat, 360},
+      {queue_index_embed_msgs_below, 0},
+      {queue_index_max_journal_entries, 8192},
+      {log_levels, [{autocluster, info},
+                    {connection, error},
+                    {channel, warning},
+                    {federation, info},
+                    {mirroring, info},
+                    {shovel, info}]},
+      {vm_memory_high_watermark, 0.8}
+    ]
+  }
+].


### PR DESCRIPTION
there is a request to override the default rabbit config in order to increase heartbeat monitor timeout.